### PR TITLE
Set buttons to use frame color

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,6 @@
       "frame_incognito": [25, 26, 33],
       "frame_incognito_inactive": [25, 26, 33],
       "bookmark_text": [248, 248, 242],
-      "button_background": [68, 71, 90],
       "tab_background_text": [98, 114, 164],
       "tab_background_text_inactive": [98, 114, 164],
       "tab_background_text_incognito": [98, 114, 164],


### PR DESCRIPTION
Fixes #9 

When `button_background` is unset, buttons use the `frame` color. This makes it consistent in both normal and incognito mode.